### PR TITLE
Demonstrate cache line ping ponging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        build_type: [ 'Release', 'Debug' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +20,7 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build
+      run: cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -B ${{github.workspace}}/build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/benchmark/matrix_bench.cpp
+++ b/benchmark/matrix_bench.cpp
@@ -20,13 +20,28 @@ template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fi
     }
 
   protected:
-    void sum_block(int idx) {
+    void sum_block_local_update(int idx) {
         const cacheline::Matrix<long>::View& block = blocks[idx];
         for (int i = 0; i < block.num_rows; ++i) {
             for (int j = 0; j < block.num_cols; ++j) {
-                block.visit(i, j, [this, &idx](long val) { partial_sums[idx] += val; });
+                long entry = 0;
+                block.visit(i, j, [&entry](long val) { entry = val; });
+                partial_sums[idx] += entry;
             }
         }
+    }
+
+    void sum_block_global_update(int idx) {
+        long sum = 0;
+        const cacheline::Matrix<long>::View& block = blocks[idx];
+        for (int i = 0; i < block.num_rows; ++i) {
+            for (int j = 0; j < block.num_cols; ++j) {
+                long entry = 0;
+                block.visit(i, j, [&entry](long val) { entry = val; });
+                sum += entry;
+            }
+        }
+        partial_sums[idx] = sum;
     }
 
     cacheline::Matrix<long> matrix{num_rows, num_cols};
@@ -34,13 +49,24 @@ template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fi
     std::vector<long> partial_sums;
 };
 
-BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntries, 16 * 1024, 32 * 1024)
+BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesLocal, 16 * 1024, 32 * 1024)
 (benchmark::State& state) {
     for (auto _ : state) {
-        sum_block(state.thread_index());
+        sum_block_local_update(state.thread_index());
     }
 }
 
-BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntries)
+BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntriesLocal)
     ->Unit(benchmark::kMillisecond)
-    ->ThreadRange(1, 64);
+    ->DenseThreadRange(1, 16, 1);
+
+BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesGlobal, 16 * 1024, 32 * 1024)
+(benchmark::State& state) {
+    for (auto _ : state) {
+        sum_block_global_update(state.thread_index());
+    }
+}
+
+BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntriesGlobal)
+    ->Unit(benchmark::kMillisecond)
+    ->DenseThreadRange(1, 16, 1);


### PR DESCRIPTION
Demonstrate the issue by summing the entries in a matrix using multiple
threads. Then, show how eliminating access to a shared memory region in
the update loop solves the problem.