### PR TITLE
Eliminate false sharing using aligned memory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        build_type: [ 'Release', 'Debug' ]
+        compiler: [g++, clang++]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,10 @@ jobs:
         submodules: recursive
 
     - name: Configure CMake
-      run: cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -B ${{github.workspace}}/build
+      env:
+        CXX: ${{matrix.compiler}}
+        BUILD_TYPE: Release
+      run: cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -B ${{github.workspace}}/build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/benchmark/matrix_bench.cpp
+++ b/benchmark/matrix_bench.cpp
@@ -4,6 +4,10 @@
 
 #include "benchmark/benchmark.h"
 
+int num_threads_max = 8;
+
+template <typename T> struct alignas(64) Aligned { T val = 0; };
+
 template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fixture {
   public:
     void SetUp(const benchmark::State& state) override {
@@ -17,6 +21,7 @@ template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fi
 
         blocks = matrix.partition(state.threads(), 1);
         partial_sums = std::vector<long>(state.threads(), 0);
+        partial_sums_aligned = std::vector<Aligned<long>>(state.threads());
     }
 
   protected:
@@ -27,6 +32,18 @@ template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fi
                 long entry = 0;
                 block.visit(i, j, [&entry](long val) { entry = val; });
                 partial_sums[idx] += entry;
+            }
+        }
+    }
+
+    void sum_block_global_update_aligned(int idx) {
+        long sum = 0;
+        const cacheline::Matrix<long>::View& block = blocks[idx];
+        for (int i = 0; i < block.num_rows; ++i) {
+            for (int j = 0; j < block.num_cols; ++j) {
+                long entry = 0;
+                block.visit(i, j, [&entry](long val) { entry = val; });
+                partial_sums_aligned[idx].val += entry;
             }
         }
     }
@@ -47,9 +64,10 @@ template <int num_rows, int num_cols> class MatrixFixture : public benchmark::Fi
     cacheline::Matrix<long> matrix{num_rows, num_cols};
     std::vector<cacheline::Matrix<long>::View> blocks;
     std::vector<long> partial_sums;
+    std::vector<Aligned<long>> partial_sums_aligned;
 };
 
-BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesLocal, 16 * 1024, 32 * 1024)
+BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesLocal, 4 * 1024, 8 * 1024)
 (benchmark::State& state) {
     for (auto _ : state) {
         sum_block_local_update(state.thread_index());
@@ -58,9 +76,9 @@ BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesLocal, 16 * 1024, 32 
 
 BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntriesLocal)
     ->Unit(benchmark::kMillisecond)
-    ->DenseThreadRange(1, 16, 1);
+    ->DenseThreadRange(1, num_threads_max, 1);
 
-BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesGlobal, 16 * 1024, 32 * 1024)
+BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesGlobal, 4 * 1024, 8 * 1024)
 (benchmark::State& state) {
     for (auto _ : state) {
         sum_block_global_update(state.thread_index());
@@ -69,4 +87,15 @@ BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesGlobal, 16 * 1024, 32
 
 BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntriesGlobal)
     ->Unit(benchmark::kMillisecond)
-    ->DenseThreadRange(1, 16, 1);
+    ->DenseThreadRange(1, num_threads_max, 1);
+
+BENCHMARK_TEMPLATE_DEFINE_F(MatrixFixture, MatrixSumEntriesGlobalAligned, 4 * 1024, 8 * 1024)
+(benchmark::State& state) {
+    for (auto _ : state) {
+        sum_block_global_update_aligned(state.thread_index());
+    }
+}
+
+BENCHMARK_REGISTER_F(MatrixFixture, MatrixSumEntriesGlobalAligned)
+    ->Unit(benchmark::kMillisecond)
+    ->DenseThreadRange(1, num_threads_max, 1);


### PR DESCRIPTION
Concurrent updates to the contiguous memory region can still be
performed if the entries are spaced far enough from one another.
Specify an alignment equal to a cacheline size to enforce this
requirement, benchmark and compare against the other experiments.